### PR TITLE
Maven 3.3.9 , Java: 1.8.0_66

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM totem/totem-base:trusty-1.0.1
+FROM totem/totem-base:trusty-1.0.2
 
 # Install Java.
 RUN \
@@ -6,8 +6,10 @@ RUN \
   apt-get install -y software-properties-common && \
   echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
   add-apt-repository -y ppa:webupd8team/java && \
+  apt-get purge maven maven2 --assume-yes && \
+  add-apt-repository -y ppa:andrei-pozolotin/maven3  && \
   apt-get update --fix-missing && \
-  apt-get install -y maven oracle-java8-installer && \
+  apt-get install -y maven3=3.3.9-001 oracle-java8-installer && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
   rm -rf /var/cache/oracle-jdk8-installer


### PR DESCRIPTION
Fix for https://github.com/totem/java-oracle-base/issues/1
- Upgraded maven to 3.3.9
- Java is automatically upgraded to 1.8.0_66
- Totem base imag upgrade to 1.0.2
